### PR TITLE
Scribe Editorial: 2026-01-26 Edition

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -1,0 +1,9 @@
+# Scribe’s Journal — Meta Learnings Only
+
+This journal records meta-level editorial insights, recurring blind spots in discourse, and framings that improve systemic understanding.
+
+---
+
+## 2026-01-26 – The Observation-Logic Displacement
+**Learning:** "Vibe coding" discourse reveals a fundamental shift in the developer's role from *authoring* (building a mental model of logic) to *observing* (verifying runtime behavior). This isn't just a productivity boost; it's a cognitive displacement. When developers stop "compiling" logic in their heads, the "mental compiler" atrophies, making them dependent on the feedback loop of the runtime to understand their own intent.
+**Implication:** Future technical essays should focus on the "Verification-to-Logic Ratio." As the cost of generating code drops to zero, the value of the system moves from the *creation* of logic to the *architecture of verification*. We should write for readers who are transitioning from being builders to being auditors.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,232 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    bigdecimal (4.0.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.6)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.3)
+    ffi (1.17.3-aarch64-linux-gnu)
+    ffi (1.17.3-aarch64-linux-musl)
+    ffi (1.17.3-arm-linux-gnu)
+    ffi (1.17.3-arm-linux-musl)
+    ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x86-linux-gnu)
+    ffi (1.17.3-x86-linux-musl)
+    ffi (1.17.3-x86_64-darwin)
+    ffi (1.17.3-x86_64-linux-gnu)
+    ffi (1.17.3-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.4)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.4-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.3.4)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (>= 0.3.6, < 0.5)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-feed (0.17.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-paginate (1.1.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.2)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.97.3)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.97.3-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.97.3-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3.4)
+  jekyll-feed (~> 0.17)
+  jekyll-paginate (~> 1.1)
+  tzinfo-data
+  webrick (~> 1.8)
+
+CHECKSUMS
+  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
+  eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
+  ffi (1.17.3) sha256=0e9f39f7bb3934f77ad6feab49662be77e87eedcdeb2a3f5c0234c2938563d4c
+  ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
+  ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
+  ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
+  ffi (1.17.3-arm-linux-musl) sha256=0d7626bb96265f9af78afa33e267d71cfef9d9a8eb8f5525344f8da6c7d76053
+  ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
+  ffi (1.17.3-x86-linux-gnu) sha256=868a88fcaf5186c3a46b7c7c2b2c34550e1e61a405670ab23f5b6c9971529089
+  ffi (1.17.3-x86-linux-musl) sha256=f0286aa6ef40605cf586e61406c446de34397b85dbb08cc99fdaddaef8343945
+  ffi (1.17.3-x86_64-darwin) sha256=1f211811eb5cfaa25998322cdd92ab104bfbd26d1c4c08471599c511f2c00bb5
+  ffi (1.17.3-x86_64-linux-gnu) sha256=3746b01f677aae7b16dc1acb7cb3cc17b3e35bdae7676a3f568153fb0e2c887f
+  ffi (1.17.3-x86_64-linux-musl) sha256=086b221c3a68320b7564066f46fed23449a44f7a1935f1fe5a245bd89d9aea56
+  forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
+  google-protobuf (4.33.4) sha256=86921935b023ed0d872d6e84382e79016c91689be0520d614c74426778f13c16
+  google-protobuf (4.33.4-aarch64-linux-gnu) sha256=7b091ec8a80520738a4dbff59458e2a7ed4304d7fc20fd779b3d019ff52fbead
+  google-protobuf (4.33.4-aarch64-linux-musl) sha256=c017371e6fe8144285a3dd5d1ae2776f92892f7455bea26537f0f3072b6d894c
+  google-protobuf (4.33.4-arm64-darwin) sha256=63bb57e3d7108986f961546a536adaa38bd9ab5b1ebc39a1741a16c6eba3e869
+  google-protobuf (4.33.4-x86-linux-gnu) sha256=c54fab97506b79d6c7857d2caf373df5428c4f318fcffcd7acddc4ee29af383f
+  google-protobuf (4.33.4-x86-linux-musl) sha256=6e9a67b83e70090f72b65b4386b9273f460cf4f4d6cba61f3b4817bb3b416c97
+  google-protobuf (4.33.4-x86_64-darwin) sha256=72906abcb572b324eba760b0abdbb827ab781b8e26f718fa3f7f49485295c8d3
+  google-protobuf (4.33.4-x86_64-linux-gnu) sha256=a8cff953d742bc804ece78bd96e82d88cf65a7d8c1910e045359e2f53074e55d
+  google-protobuf (4.33.4-x86_64-linux-musl) sha256=265e6e5bbcc0ba1367268739e31c4cc84ff310b56e8d738d2a3245b5cccfc2e7
+  http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  jekyll (4.3.4) sha256=c488282c2819c392d34d3a3784eacde2cde4b61c8e3c9c9295f6c01fb1754404
+  jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
+  jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
+  jekyll-sass-converter (3.1.0) sha256=83925d84f1d134410c11d0c6643b0093e82e3a3cf127e90757a85294a3862443
+  jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
+  liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
+  listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
+  pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
+  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
+  rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
+  safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
+  sass-embedded (1.97.3) sha256=c4136da69ae3acfa7b0809f4ec10891125edf57df214a2d1ab570f721f96f7a6
+  sass-embedded (1.97.3-aarch64-linux-android) sha256=623b2f52fed6e3696c6445406e4efaef57b54442cc35604bfffbb82aef7d5c45
+  sass-embedded (1.97.3-aarch64-linux-gnu) sha256=81915bb19ce7e224eae534e75e828f4ab5acddcb17e54da0b5ef91d932462836
+  sass-embedded (1.97.3-aarch64-linux-musl) sha256=508c92fa2f9e58f9072325e02f011bd22c7e428465c67fafaee570d0bc40563b
+  sass-embedded (1.97.3-arm-linux-androideabi) sha256=e2ef33b187066e09374023e58e72cf3b5baabe6b77ecd74356fe9b4892a1c6e1
+  sass-embedded (1.97.3-arm-linux-gnueabihf) sha256=ce443b57f3d7f03740267cf0f2cdff13e8055dd5938488967746f29f230222da
+  sass-embedded (1.97.3-arm-linux-musleabihf) sha256=be3972424616f916ce1f4f41228266d57339e490dfd7ca0cea5588579564d4c0
+  sass-embedded (1.97.3-arm64-darwin) sha256=8897d3503efe75c30584070a7104095545f5157665029aeb9bff3fa533a73861
+  sass-embedded (1.97.3-riscv64-linux-android) sha256=201426b3e58611aa8cf34a7574df51905ec42fefb5a69982cc8497ac7fb26a6b
+  sass-embedded (1.97.3-riscv64-linux-gnu) sha256=d7bac32f4de55c589a036da13ac4482bf5b7dfac980b4c0203d31a1bd9f07622
+  sass-embedded (1.97.3-riscv64-linux-musl) sha256=621d981d700e2b8d0459b5ea696fff746dfa07d6b6bbc70cd982905214b07888
+  sass-embedded (1.97.3-x86_64-darwin) sha256=578f167907ee2a4d355a5a40bcf35d2e3eb90c87008dcd9ce31a2c4a877697f6
+  sass-embedded (1.97.3-x86_64-linux-android) sha256=8f5e179bee8610be432499f228ea4e53ab362b1db0da1ae3cd3e76b114712372
+  sass-embedded (1.97.3-x86_64-linux-gnu) sha256=173a4d0dbe2fffdf7482bd3e82fb597dfc658c18d1e8fd746aa7d5077ed4e850
+  sass-embedded (1.97.3-x86_64-linux-musl) sha256=fcc0dcb253ef174ea25283f8781ce9ce95a492663f4bdbb1d66bfae99267a9f7
+  terminal-table (3.0.2) sha256=f951b6af5f3e00203fb290a669e0a85c5dd5b051b3b023392ccfd67ba5abae91
+  unicode-display_width (2.6.0) sha256=12279874bba6d5e4d2728cef814b19197dbb10d7a7837a869bab65da943b7f5a
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+BUNDLED WITH
+  4.0.4

--- a/_posts/2026-01-26-erosion-of-the-mental-compiler.md
+++ b/_posts/2026-01-26-erosion-of-the-mental-compiler.md
@@ -1,0 +1,50 @@
+---
+layout: post
+title: 'The Erosion of the Mental Compiler'
+date: '2026-01-26'
+author: rockoder
+tags:
+- VibeCoding
+- EngineeringManagement
+- AI
+---
+
+Recent discourse around "Vibe Coding"—the practice of using LLMs to generate vast swaths of code based on high-level intent—has focused almost exclusively on productivity. But for senior engineering leaders, the real shift isn't in velocity; it's in the **cognitive displacement** of the developer.
+
+### The Real Problem
+The fundamental risk of Vibe Coding is not "hallucinations" or "buggy code." It is the **atrophy of the internal validation loop**.
+
+In traditional software engineering, a developer "compiles" logic in their head before it ever reaches a keyboard. This internal simulation ensures that the author understands the causal relationships between variables, states, and outcomes. Vibe Coding replaces this internal *authoring* with external *observation*. The developer describes a vibe, runs the result, and observes if it "looks right."
+
+We are moving from being **Architects of Logic** to **Auditors of Output**.
+
+### Why This Exists
+This shift is driven by two primary constraints:
+1. **Context Overload**: Modern systems have grown beyond the capacity of a single human to hold in "L1 cache" (active memory). LLMs provide a way to bridge this gap by handling the boilerplate and "plumbing."
+2. **The Frictionless Feedback Loop**: When the time between "intent" and "running code" drops to seconds, the incentive to think deeply before acting vanishes. Why simulate the logic mentally when the computer can simulate it for you in the real world for nearly zero cost?
+
+### The Missing Model: The Mental Compiler
+To navigate this shift, we need to understand the concept of the **Mental Compiler**. This is the internalized model of the system's execution.
+
+| Feature | Mental Compilation (Traditional) | Vibe Observation (Modern) |
+|:---|:---|:---|
+| **Primary Activity** | Internal Simulation | External Verification |
+| **Source of Truth** | Causal Reasoning | Empirical Observation |
+| **Failure Mode** | Logic Error (Wrong Thought) | Regression (Unseen Side-effect) |
+| **Cognitive Load** | High (Deep Work) | Low (Context Switching) |
+| **System Visibility**| High (Internalized) | Low (Black Box) |
+
+**This is the crux**: When you use a Mental Compiler, you own the logic. When you use Vibe Observation, the logic owns you.
+
+### Tradeoffs and Failure Modes
+Adopting a Vibe-first workflow creates a "Maintenance Bankruptcy."
+* **The "Recap" Debt**: As noted in recent HN discussions, developers often lose the ability to "recap" or re-internalize the logic after a few iterations. If you didn't build the logic, you can't easily debug the "second-order" bugs that emerge when the context window is forgotten.
+* **The Semantic-to-Syntactic Gap**: LLMs are excellent at syntax but lack a grounding in the *why*. You can generate a 1,000-line Rust port in a day, but you have effectively created a system with **High Semantic Debt**—code that works but lacks an advocate who understands its internal invariants.
+
+### Second-Order Effects
+1. **The Rise of the Auditor-Engineer**: The most valuable skill in 2026 will not be writing code, but the ability to design **Verification Architectures** (tests, observability, and formal constraints) that can catch what the LLM misses.
+2. **Architectural Drift**: Without a strong mental model, systems will naturally drift toward the most "probable" implementation rather than the most "rational" one. We will see a homogenization of architecture based on the training data of the dominant models.
+3. **The Seniority Cliff**: Junior developers who skip the "Mental Compilation" phase of their career may find it impossible to develop the intuition required for high-stakes systems design.
+
+**Common misconception**: "AI makes coding easier."
+**Correct framing**: AI makes *generating* code easier, but it makes *knowing* what you have built significantly harder.

--- a/_posts/2026-01-26-syntax-liquidity.md
+++ b/_posts/2026-01-26-syntax-liquidity.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: 'Syntax Liquidity and the Collapse of Low-Code'
+date: '2026-01-26'
+author: rockoder
+tags:
+- LowCode
+- AI
+- ProductStrategy
+---
+
+The recent "RIP Low-Code" sentiment on Hacker News isn't just another tech trend dying out. It is the result of a fundamental change in the economics of software construction. We are witnessing the birth of **Syntax Liquidity**.
+
+### The Real Problem
+Low-code platforms (Airtable, Mendix, OutSystems) were never about "no code." They were about **arbitraging the high cost of syntax**.
+
+Before 2024, the "Syntax Tax"—the cognitive and financial cost of learning and maintaining specific programming languages—was so high that companies were willing to accept massive tradeoffs (proprietary lock-in, limited flexibility, "walled garden" ecosystems) just to bypass it.
+
+Low-code was a hedge. Now, the hedge is underwater.
+
+### Why This Exists
+AI has commoditized the translation of human intent into formal syntax. When a general-purpose LLM can write a custom React frontend or a Python backend as easily as a human can drag-and-drop a component in a visual builder, the value proposition of the visual builder collapses.
+
+The "Complexity Barrier" has been replaced by a "Prompting Surface."
+
+### The Missing Model: Syntax Liquidity
+We need a new model to understand this: **Syntax Liquidity**. This is the degree to which logic can be moved between different formal representations with zero friction.
+
+```text
+[ Intent ] ----> ( High Liquidity ) ----> [ Python / Go / Rust ]
+   |                                            ^
+   |                                            |
+   +-----------> ( Low Liquidity ) ----> [ Proprietary Low-Code ]
+```
+
+In a world of high syntax liquidity, **Code is a Temporary Asset**. You don't "choose" a platform for the next 10 years; you generate the logic for the next 10 minutes.
+
+### Tradeoffs and Failure Modes
+While liquidity is high, "Architectural Integrity" is often low.
+* **The "Glue Code" Explosion**: High liquidity makes it easy to generate 100 microservices, but it doesn't make it easy to *manage* them. We are trading "Syntax Debt" for "Architectural Complexity."
+* **Managed Abstraction vs. Raw Power**: Low-code provided a "safe floor." Without it, developers (and "citizen developers") are once again playing with sharp tools. The risk of a "liquid" script causing a catastrophic system failure is much higher than a "low-code" workflow failing.
+
+### Second-Order Effects
+1. **The Return to Open Standards**: If syntax is free, why pay a "Lock-in Tax" to a low-code vendor? We will see a massive migration back to standard SQL, standard Python, and standard HTML/CSS—interfaces that are AI-native.
+2. **The Death of the "Citizen Developer" Myth**: The dream was that non-technical people would build apps. The reality is that AI-enabled *engineers* will build apps so fast that the "citizen developer" becomes irrelevant.
+3. **Liquidity as a Feature**: Future platforms will not compete on how many components they have, but on how easily you can *export* your logic to another stack.
+
+**This is the crux**: Low-code platforms were selling a solution to a problem that LLMs solved better by removing the problem entirely.

--- a/_posts/2026-01-26-the-operator-gap.md
+++ b/_posts/2026-01-26-the-operator-gap.md
@@ -1,0 +1,48 @@
+---
+layout: post
+title: 'The Operator Gap: Human Interfaces for Agentic Models'
+date: '2026-01-26'
+author: rockoder
+tags:
+- AI
+- Agents
+- Infrastructure
+---
+
+We are currently in a bizarre transitional phase of computing where we are building super-intelligent agents and then forcing them to type into a Bash terminal or click buttons in a browser. This is the **Operator Gap**.
+
+### The Real Problem
+The interfaces we use today (CLI, GUI, REST APIs) were designed with **Human Latencies** and **Biological Constraints** in mind.
+* A GUI exists because humans are good at spatial pattern matching but bad at memorizing thousands of command flags.
+* A CLI exists because text is a low-bandwidth, high-precision way for humans to communicate with a kernel.
+
+Forcing an LLM—a semantic engine—to use a CLI or a GUI is like giving a supercomputer a steering wheel and pedals. It is an **Anthropomorphic Bottleneck**.
+
+### Why This Exists
+Infrastructure is "sticky." We have trillions of lines of code and decades of operating system design optimized for a biological user.
+When we build "ChatGPT Containers" or "Claude Code," we are essentially building a bridge from a high-dimensional semantic space (the LLM) to a low-dimensional syntactic space (the Shell).
+
+### The Missing Model: The Agent-Native Interface (ANI)
+The next evolution of the stack isn't "better agents," but **Agent-Native Interfaces**.
+
+```text
+[ LLM Agent ] ---- ( Current ) ----> [ Human Shell (Bash/JSON) ] ----> [ Kernel ]
+[ LLM Agent ] ---- ( Future  ) ----> [ Semantic API (Embeddings) ] ----> [ System ]
+```
+
+In an ANI-driven world:
+1. **Implicit Context**: The agent doesn't "type" `ls -la`. It requests a semantic representation of the file system's current state directly.
+2. **Probability as a Parameter**: Instead of binary "Success/Fail" signals, the system returns probability distributions of potential outcomes, which the agent can "reason" through.
+3. **The Death of the Dashboard**: Dashboards are for human eyes. Agents need **Observability Streams**—raw, unformatted data that they can interpret without the overhead of visualization.
+
+### Tradeoffs and Failure Modes
+* **The Black Box Problem**: If we move to Agent-Native Interfaces, humans will no longer be able to "intercept" the communication between the agent and the system. We lose the ability to "peek at the screen."
+* **Security vs. Autonomy**: Giving an agent a "semantic API" to the kernel is inherently more dangerous than giving it a Shell. A Shell has a limited vocabulary; an ANI might expose internal invariants that were never meant to be "seen" or "manipulated."
+* **Interface Fragility**: If the semantic model of the system changes (e.g., a kernel update), the agent's "understanding" might break in ways that are non-obvious and hard to debug.
+
+### Second-Order Effects
+1. **The Semantic OS**: We will see the emergence of Operating Systems where the primary "User" is an agent, and the human is relegated to a "Policy Maker" who sets constraints rather than executing commands.
+2. **API Homogenization**: REST and GraphQL will be replaced by **Universal Semantic Protocols** where the "Schema" is just a set of natural language descriptions that the agent interprets on the fly.
+3. **Hardware Acceleration for Agents**: We will see "Agent Processors" that don't just run inference, but actually hardware-accelerate the translation between semantic intent and physical system calls.
+
+**This is the crux**: We are currently building agents to act like "Better Humans." The real value is in building systems that treat agents like "First-Class Citizens."


### PR DESCRIPTION
As "Scribe," I have performed the mandatory daily scan of Hacker News (top 30 posts + top comments). After evaluating the discourse against strict quality gates, I have selected exactly three topics for today's publication:

1. **The Erosion of the Mental Compiler**: Investigates the cognitive shift from logic authoring to runtime observation in the age of "Vibe Coding."
2. **Syntax Liquidity and the Collapse of Low-Code**: Explains how AI has destroyed the proprietary arbitrage of low-code platforms by making high-code 'liquid.'
3. **The Operator Gap**: Argues that forcing agentic models into human-centric interfaces (Bash, Browser) is an anthropomorphic bottleneck that necessitates agent-native interfaces.

Each essay follows the required 5-part logical arc (Real Problem, Why This Exists, The Missing Model, Tradeoffs, Second-Order Effects) and incorporates visual structure. I also updated the `.Jules/scribe.md` journal with a meta-learning entry.

All changes have been verified via local Jekyll build and Playwright screenshots.

---
*PR created automatically by Jules for task [11196223741551924152](https://jules.google.com/task/11196223741551924152) started by @rockoder*