### PR TITLE
feat: add reading progress bar and smooth scrolling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,14 +20,26 @@
       document.addEventListener('DOMContentLoaded', () => {
         {% if page.layout == "post" or page.layout == "tweet" %}
         const progressBar = document.getElementById('reading-progress-bar');
-        if (progressBar) {
+        const post = document.querySelector('.post');
+        if (progressBar && post) {
           const updateProgress = () => {
-            const winScroll = window.scrollY || document.documentElement.scrollTop;
-            const height = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-            const scrolled = height > 0 ? (winScroll / height) * 100 : 0;
-            progressBar.style.width = scrolled + '%';
+            const winScroll = window.scrollY;
+            const windowHeight = window.innerHeight;
+            const postRect = post.getBoundingClientRect();
+            const postBottom = postRect.bottom + winScroll;
+            const totalScrollable = postBottom - windowHeight;
+
+            if (totalScrollable <= 0) {
+              progressBar.parentElement.style.display = 'none';
+            } else {
+              progressBar.parentElement.style.display = 'block';
+              let percentage = (winScroll / totalScrollable) * 100;
+              percentage = Math.max(0, Math.min(100, percentage));
+              progressBar.style.width = percentage + '%';
+            }
           };
           window.addEventListener('scroll', updateProgress);
+          window.addEventListener('resize', updateProgress);
           updateProgress();
         }
         {% endif %}


### PR DESCRIPTION
Implement a sticky reading progress bar that:
- Appears only on individual post and tweet layouts.
- Tracks progress specifically for the main content area (excluding Related Posts/Comments).
- Automatically hides if the content fits entirely within the viewport.
- Uses ARIA attributes for accessibility.

Enable site-wide smooth scrolling while respecting user preferences for reduced motion.

Updated .Jules/palette.md with UX and implementation learnings.