### PR TITLE
Fix reading progress bar initial value

### DIFF
--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -10,15 +10,25 @@
 
   if (progressBar && article) {
     const updateProgress = () => {
-      const articleTop = article.offsetTop;
-      const articleHeight = article.offsetHeight;
+      const rect = article.getBoundingClientRect();
+      const articleTop = rect.top + window.scrollY;
+      const articleHeight = rect.height;
       const windowHeight = window.innerHeight;
       const scrollY = window.scrollY;
 
-      // Calculate progress within the article
-      const scrollableDistance = articleHeight - windowHeight + articleTop;
-      const scrolled = Math.max(0, scrollY - articleTop + windowHeight);
-      const progress = Math.min(100, (scrolled / scrollableDistance) * 100);
+      // Calculate the total scrollable distance from the top of the page
+      // to the point where the bottom of the article reaches the bottom of the viewport.
+      const scrollRange = articleTop + articleHeight - windowHeight;
+
+      let progress = 0;
+      if (scrollRange > 0) {
+        // Start at 0% when the page is at the top (scrollY = 0)
+        // and reach 100% at the end of the article.
+        progress = Math.max(0, Math.min(100, (scrollY / scrollRange) * 100));
+      } else {
+        // If the article is already fully visible, progress is 100%.
+        progress = 100;
+      }
 
       progressBar.style.width = `${progress}%`;
     };


### PR DESCRIPTION
The reading progress bar was showing ~25% progress even when a post was just opened at the top of the page. This was due to the calculation logic which considered the portion of the article visible in the initial viewport as "completed".

I updated `src/components/ReadingProgress.astro` with a new formula:
- `scrollRange = articleTop + articleHeight - windowHeight`
- `progress = scrollY / scrollRange`

This ensures that at `scrollY = 0`, the progress is `0%`. The progress reaches `100%` when the bottom of the article aligns with the bottom of the viewport. I also used `getBoundingClientRect()` for more robust element positioning.

Verified the fix using Playwright screenshots and build checks.

---
*PR created automatically by Jules for task [9015881955667487806](https://jules.google.com/task/9015881955667487806) started by @rockoder*