### PR TITLE
Daily Scribe: 3 high-signal essays from Hacker News scan

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -1,3 +1,15 @@
 ## 2026-02-01 - [Automated Technical Content Extraction from Hacker News]
 **Learning:** Automated curation of high-quality technical content from Hacker News requires a multi-layered extraction strategy. `trafilatura` is superior for isolating "clean" article bodies from diverse domains, while internal HN posts (Ask/Show HN) must be treated as first-party content by targeting the `toptext` container. Hierarchical comment extraction is most robust when using the specific `indent` attribute now present in HN's markup, falling back to legacy image-width heuristics only when necessary.
 **Implication:** Future curation scripts should prioritize data attributes over structural position to maintain resilience against minor markup changes, and use specialized NLP/scraping libraries like `trafilatura` to ensure expert-level content density without UI clutter.
+
+## 2026-02-03 - [The 'Hot Mess' Mode and the Failure of Intentionality]
+**Learning:** Technical discourse is shifting from "AI Ethics/Alignment" (Bias) to "AI Stability/Reliability" (Variance). The "Hot Mess" theory—where harder tasks increase stochastic incoherence regardless of accuracy—provides a much more precise model for industrial-scale AI risk than the "Paperclip Maximizer" narrative.
+**Implication:** Essays targeting senior engineers should reframe "Safety" as "Operational Stability" and "System Reliability," focusing on architectural "breakwaters" rather than ethical guardrails.
+
+## 2026-02-03 - [Brand Dilution in the Agentic OS]
+**Learning:** Forced ubiquity is the enemy of specialized utility. Microsoft’s attempt to brand all AI as "Copilot" creates a naming collision with reality that alienates power users. Internal tool choices (Microsoft devs using Claude) are the ultimate leading indicator of brand failure in the developer space.
+**Implication:** Authority in technical writing comes from identifying where "Distribution Advantages" (bundling) collide with "Product Utility" (specialized tools).
+
+## 2026-02-03 - [The Ambiguity Tax of Vibe Coding]
+**Learning:** "Vibe coding" is a culture of disposability that shifts the discovery of ambiguity from the design phase to the production phase. The recurring failure of Supabase RLS security in vibe-coded apps is a symptom of a larger "Ambiguity-to-Code" ratio problem where implementation velocity hides requirements rot.
+**Implication:** Future essays should center the developer's role as an "Ambiguity Reducer" rather than a "Code Generator" to maintain relevance in an AI-commoditized implementation landscape.

--- a/src/content/blog/ai-as-an-industrial-accident.md
+++ b/src/content/blog/ai-as-an-industrial-accident.md
@@ -1,0 +1,59 @@
+---
+title: "The 'Hot Mess' Mode: AI Safety as Operational Stability"
+date: 2026-02-04
+author: "Ganesh Pagade"
+tags: ["ai-safety", "alignment", "engineering", "complexity"]
+description: "Why the biggest risk to AI deployment isn't 'evil intent' but 'stochastic incoherence'—the scaling of the hot mess."
+draft: false
+---
+
+The common discourse on AI safety is obsessed with "Intentional Misalignment"—the fear that a superintelligent AI will pursue a goal (like making paperclips) with such ruthless efficiency that it destroys humanity as a side effect. It assumes a coherent, high-functioning optimizer.
+
+But new research from Anthropic suggests a more chaotic reality: as tasks get harder and reasoning chains get longer, AI failure is dominated not by **Bias** (systematic goal pursuit) but by **Variance** (incoherence).
+
+In other words: the AI doesn't fail because it wants the wrong thing; it fails because it becomes a "Hot Mess."
+
+### The Real Problem: The Stochastic Horizon
+
+The real problem is the **Stochastic Horizon**. For any given model, there is a limit to how many sequential reasoning steps it can take before the "noise" of its probabilistic next-token prediction overrides the "signal" of its goal.
+
+When a model is within its reasoning budget, it acts like an optimizer. When it exceeds that budget, it behaves like a "hot mess"—self-undermining, distracted, and incoherent. The danger is that we are building systems that *look* like optimizers but *fail* like industrial accidents.
+
+### Why This Exists: The Transformer's "Memory" Tax
+
+Transformers are dynamical systems, not logical engines. Every token generated is a trajectory in high-dimensional space.
+
+1.  **Context Pollution:** Every previous thought (token) becomes part of the input for the next thought. If a model makes one minor "incoherent" step, that incoherence is now part of its "truth" for the next step.
+2.  **The Reasoning Budget:** Scaling intelligence (model size) improves accuracy on simple tasks, but on truly hard problems, it just allows the model to "hallucinate with more confidence" for longer, before eventually collapsing into variance.
+
+### The Missing Model: The Bias-Variance Safety Lens
+
+We should view AI safety through the lens of classical machine learning error decomposition.
+
+| Risk Profile | Error Type | Outcome | Narrative |
+| :--- | :--- | :--- | :--- |
+| **High Bias / Low Var** | Systematic | "The Paperclip Maximizer" | Coherent but perfectly misaligned. |
+| **Low Bias / High Var** | Incoherent | "The Hot Mess" | Well-intentioned but self-undermining. |
+| **High Bias / High Var** | Compound | "Production Reality" | Chaotic, unpredictable failure modes. |
+
+Most alignment research is focused on the **Bias** component (making sure the AI "wants" what we want). But as we move toward agentic systems that take thousands of actions, the **Variance** component becomes the dominant risk. A "well-aligned" agent that is incoherent is just as dangerous in a nuclear power plant as a "misaligned" one that is coherent.
+
+### Tradeoffs and Failure Modes
+
+The primary tradeoff in managing incoherence is **Autonomy vs. Verification**.
+
+*   **The Chain-of-Thought Trap:** Encouraging longer reasoning (Chain-of-Thought) can increase accuracy, but it also increases the surface area for "incoherence spikes." The longer the model "thinks," the more likely it is to drift into a "domain valley" where its reasoning becomes untethered from reality.
+*   **The "Recursive Summary" Failure:** Using sub-agents to summarize context (to save the caller's token budget) reduces variance but risks losing critical "low-probability" edge cases that a senior human would have spotted.
+
+### Second-Order Effects: From "Ethics" to "Reliability"
+
+The second-order effect of this shift is that **AI Safety will merge with Reliability Engineering**.
+
+We will stop asking "is this AI ethical?" and start asking "is this AI stable?" Safety will be measured in terms of **Incoherence Spikes** and **Reasoning Budgets** rather than just reward-modeling or prompt-injection resistance.
+
+Senior engineers will need to design "breakwaters" for AI agents—architectural constraints that force an agent to reset its context or verify its state before its variance-driven incoherence leads to an irreversible industrial accident.
+
+The future of AI risk isn't a rebellion; it's a meltdown.
+
+---
+*Inspired by the research at Anthropic: [How does misalignment scale with model intelligence and task complexity?](https://alignment.anthropic.com/2026/hot-mess-of-ai/)*

--- a/src/content/blog/the-ambiguity-tax.md
+++ b/src/content/blog/the-ambiguity-tax.md
@@ -1,0 +1,67 @@
+---
+title: "The Ambiguity Tax: Why Code Generation is the Wrong Metric"
+date: 2026-02-05
+author: "Ganesh Pagade"
+tags: ["software-engineering", "ai", "productivity", "management"]
+description: "Why AI coding assistants are increasing technical debt by shifting the discovery of ambiguity from the design phase to the production phase."
+draft: false
+---
+
+The current "productivity" metrics for AI coding assistants are fundamentally flawed. We measure "PRs per hour," "lines of code generated," or "acceptance rate." We celebrate the fact that a developer can now "one-shot" a feature that used to take a week.
+
+But as any senior engineer knows, **typing is not the bottleneck of software engineering**. Ambiguity is.
+
+By focusing on making the "easy part" (writing code) 20x faster, we are creating an **Ambiguity Tax** that is being paid for in downstream technical debt and security vulnerabilities.
+
+### The Real Problem: Shifting Failure to the Right
+
+In the traditional software development lifecycle (SDLC), the goal of a senior developer is to **reduce ambiguity as early as possible**. You poke holes in the requirements, you identify edge cases in the data model, and you negotiate the contract before you ever open an IDE.
+
+AI coding assistants encourage the opposite. They allow you to bypass the "uncomfortable" part of requirements clarification and jump straight to implementation.
+
+```text
+The SDLC Failure Shift:
+
+Traditional: [ Design/Clarify (Hard) ] -> [ Code (Easy) ] -> [ Test ]
+AI-Driven:   [ Prompt (Easy) ] -> [ AI Code (Fast) ] -> [ Debug/Review (EXCRUCIATING) ]
+```
+
+The problem is that **reading code is harder than writing code**. When an AI generates 500 lines of "legitimate-looking" code that conceals a fundamental requirements gap, you haven't saved time. You've just shifted the failure "to the right"—into the code review, the QA phase, or worse, production.
+
+### Why This Exists: The Throughput Illusion
+
+The incentive for management is "Velocity." High-throughput AI code generation *looks* like velocity on a Jira board.
+
+But this is an illusion. We are confusing **Technical Output** with **Business Value**. A junior developer with an AI can now produce a high volume of code that follows a suboptimal architectural path. Because they haven't "suffered" through the assumptions required to write that code manually, they are ill-equipped to defend its logic during review.
+
+### The Missing Model: The Ambiguity-to-Code Ratio
+
+We need to start measuring the **Ambiguity-to-Code Ratio**.
+
+A high-quality software project has a low ratio: the requirements are clear, the edge cases are known, and the code follows naturally. AI coding tools, in their current "vibe-coded" application, are artificially inflating the denominator (Code) without reducing the numerator (Ambiguity).
+
+| Phase | Human-Centric | AI-Centric (Naive) |
+| :--- | :--- | :--- |
+| **Requirements** | "Does this handle the null state?" | "Just build it, I'll prompt more later." |
+| **Implementation** | Slow, iterative, clarifying. | Instant, voluminous, opaque. |
+| **Review** | Logic-focused. | "Does this vibes?" / Formatting-focused. |
+| **Maintenance** | Knowledge is in the dev's head. | Knowledge is in a dead chat history. |
+
+### Tradeoffs and Failure Modes
+
+The primary failure mode of AI-augmented engineering is the **Reviewer’s Fatigue**.
+
+1.  **The "LGTM" Drift:** When a developer is forced to review hundreds of lines of AI-generated code daily, their critical thinking naturally degrades. They start looking for "bugs" (syntax errors) rather than "flaws" (architectural mismatches).
+2.  **The Vibe-Coding Security Gap:** As seen in the recent Moltbook data leak, "vibe-coding" often means omitting boring-but-critical things like Row Level Security (RLS) because the AI wasn't explicitly prompted to include them, and the developer didn't "feel" the need to add them during a manual build.
+3.  **The Stagnation of the "Junior":** Junior developers learn by wrestling with ambiguity. If the AI handles all the "messy" parts, we are producing a generation of "Reviewers" who have never actually been "Builders."
+
+### Second-Order Effects: The Rise of the Product Engineer
+
+The second-order effect of this crisis is the **Death of the "Coder" and the Birth of the "Product Engineer."**
+
+If AI can handle the implementation, the only remaining value-add for a human is **Ambiguity Reduction**. The senior engineer of the future isn't the one who knows the most esoteric syntax; it's the one who can elicit the most precise requirements from stakeholders and ensure they are represented in the AI's context.
+
+We don't need bots that write better code. We need bots that ask better questions. Until we bridge the "Empathy Gap" between product intent and code implementation, we are just using AI to build a faster treadmill of technical debt.
+
+---
+*Inspired by the discussion on HN: [Coding assistants are solving the wrong problem](https://www.bicameral-ai.com/blog/introducing-bicameral) and [Hacking Moltbook](https://www.wiz.io/blog/exposed-moltbook-database-reveals-millions-of-api-keys)*

--- a/src/content/blog/the-copilot-branding-paradox.md
+++ b/src/content/blog/the-copilot-branding-paradox.md
@@ -1,0 +1,56 @@
+---
+title: "The Copilot Branding Paradox: Why Ubiquity is the Enemy of Utility"
+date: 2026-02-03
+author: "Ganesh Pagade"
+tags: ["product-strategy", "ai", "microsoft", "branding"]
+description: "How Microsoft’s 'AI in everything' strategy is diluting its most valuable developer brand and creating a 'choice vs. default' crisis."
+draft: false
+---
+
+Microsoft is currently engaged in one of the most aggressive brand-stretching exercises in the history of software. Everything—from the Windows kernel to the Notepad menu—is being rebranded or infused with "Copilot."
+
+But as the recent reports of Microsoft’s own engineering teams favoring Anthropic’s Claude Code over GitHub Copilot suggest, the "AI in everything" strategy is hitting a wall of reality. By trying to make Copilot a universal commodity, Microsoft is accidentally destroying its status as a specialized tool.
+
+### The Real Problem: Brand Dilution via Forced Ubiquity
+
+The fundamental problem isn't that Microsoft has bad models; it's that it has a **Naming Collision with Reality**.
+
+When a brand name like "Copilot" is used to describe both a world-class developer tool (GitHub Copilot) and a mediocre, forced integration in Windows Paint or Notepad, the brand loses its signal. For a senior engineer, "Copilot" used to mean "a powerful inference engine for my codebase." Now, "Copilot" often means "that button I need to disable in my OS to reclaim RAM."
+
+### Why This Exists: The Distribution Incentive
+
+Microsoft’s incentive is driven by its massive distribution advantage. If you own the OS, the office suite, and the cloud, your primary lever for growth is **Bundling**. The logic is: "If we put a Copilot button in front of every user, we win the AI race through sheer exposure."
+
+This is the classic "Office-ification" of AI. It worked for Teams (by bundling it with Office 365), but AI is not a utility like chat or email. AI is a non-deterministic inference layer. When you bundle a non-deterministic tool into a deterministic environment (like a text editor or a spreadsheet), you don't increase productivity; you increase the **Review Burden**.
+
+### The Missing Model: The Specialist-Commodity Spectrum
+
+We need to evaluate AI tools on a spectrum from **Specialized Utility** to **General Commodity**.
+
+| Attribute | Specialized (e.g., Claude Code, Cursor) | Commodity (e.g., Windows Copilot, Notepad AI) |
+| :--- | :--- | :--- |
+| **User Intent** | Active, high-stakes, task-specific | Passive, low-stakes, generic |
+| **Trust Requirement** | High (must be correct or fail early) | Low (nice-to-have, "vibe" based) |
+| **Integration Depth** | Deep (filesystem, shell, LSP) | Surface (UI buttons, floating windows) |
+| **Value Driver** | Time saved / Complexity reduced | Novelty / Ease of discovery |
+
+The failure at Microsoft is trying to occupy both ends of the spectrum with the same name. When you try to be a general commodity, you lose the trust required to be a specialized utility.
+
+### Tradeoffs and Failure Modes
+
+The tradeoff for Microsoft’s ubiquity is **Expert Alienation**.
+
+1.  **The Dogfooding Signal:** When your own developers use a competitor's tool, you've lost the "Product-Market Fit" war, regardless of your "Product-Marketing" success.
+2.  **The Feature Parity Trap:** By focusing on putting "AI buttons" everywhere, the core product (GitHub Copilot) has stagnated. It became an enterprise compliance tool rather than a developer-first tool.
+3.  **The "Clippy" Resurgence:** Forced AI integrations that provide no clear value (like AI in Notepad) create a negative pavlovian response. Users learn to ignore the brand entirely.
+
+### Second-Order Effects: The Rise of the "Agnostic" Stack
+
+The second-order effect of this branding collapse is that the industry is moving toward an **Agnostic AI Stack**.
+
+Sophisticated teams are decoupling their "Harness" (the tool they use, like Claude Code or a custom CLI) from their "Model" (the backend). Microsoft wanted to own the whole stack via the "Copilot" brand, but by overextending it, they have accelerated the trend of developers seeking tools that let them swap models at will.
+
+If everything is a Copilot, then nothing is. The winner of the next phase of AI isn't the one with the most buttons; it's the one with the most trusted context.
+
+---
+*Inspired by the discussion on HN: [Claude Code is suddenly everywhere inside Microsoft](https://www.theverge.com/tech/865689/microsoft-claude-code-anthropic-partnership-notepad)*

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -3,7 +3,9 @@ import { getCollection, type CollectionEntry } from 'astro:content';
 import PostLayout from '../../layouts/PostLayout.astro';
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
+  const posts = await getCollection('blog', ({ data }) => {
+    return import.meta.env.PROD ? !data.draft : true;
+  });
   return posts.map((post) => ({
     params: { slug: post.slug },
     props: { post },


### PR DESCRIPTION
I have completed the daily Hacker News scan and identified three high-signal topics worthy of publication. I authored three structured technical essays that frame underlying problems and provide new mental models for expert readers.

Key deliverables:
1. **The Copilot Branding Paradox**: Analysis of how brand ubiquity at Microsoft is diluting the utility of specialized developer tools.
2. **AI as an Industrial Accident**: Reframing AI safety through the lens of 'Hot Mess' theory and stochastic incoherence scaling.
3. **The Ambiguity Tax**: Explaining why code generation speed is an illusion if it increases upstream requirements debt.

I also fixed a bug in the blog's routing logic that allowed draft posts to be built in production, and recorded meta-level editorial insights in the journal. Raw scraping data and unrequested lockfiles were excluded from the final submission to maintain repository hygiene.

---
*PR created automatically by Jules for task [1588545913132015930](https://jules.google.com/task/1588545913132015930) started by @rockoder*