### PR TITLE
Add three high-signal technical essays from Hacker News scan

### DIFF
--- a/.Jules/scribe.md
+++ b/.Jules/scribe.md
@@ -1,3 +1,7 @@
 ## 2026-02-01 - [Automated Technical Content Extraction from Hacker News]
 **Learning:** Automated curation of high-quality technical content from Hacker News requires a multi-layered extraction strategy. `trafilatura` is superior for isolating "clean" article bodies from diverse domains, while internal HN posts (Ask/Show HN) must be treated as first-party content by targeting the `toptext` container. Hierarchical comment extraction is most robust when using the specific `indent` attribute now present in HN's markup, falling back to legacy image-width heuristics only when necessary.
 **Implication:** Future curation scripts should prioritize data attributes over structural position to maintain resilience against minor markup changes, and use specialized NLP/scraping libraries like `trafilatura` to ensure expert-level content density without UI clutter.
+
+## 2026-02-05 - [The "Vibe-Coding" vs. Senior Judgment Split]
+**Learning:** Hacker News discourse around AI coding tools reveals a widening gap between "Capability Enthusiasts" (who see authoring speed as the primary metric) and "Systems Realists" (who see maintenance, liability, and governance as the primary constraints). Disagreements often stem from conflating the cost of *writing* software with the cost of *owning* it.
+**Implication:** Technical writing for this audience must bridge this gap by explicitly acknowledging the systems-level "second S" (Service/Responsibility) rather than just arguing about the "first S" (Software/Authoring).

--- a/src/content/blog/the-plumbing-of-volatility.md
+++ b/src/content/blog/the-plumbing-of-volatility.md
@@ -1,0 +1,59 @@
+---
+title: "The Plumbing of Volatility: Beyond the AI CapEx Narrative"
+date: 2026-02-07
+author: "Ganesh Pagade"
+tags: ["finance", "macro", "liquidity", "carry-trade"]
+description: "Recent market volatility is a mechanical deleveraging event from the Japanese Yen carry trade unwind, revealing the fragility of global financial plumbing."
+draft: true
+---
+
+Whenever the market enters a period of "quiet chaos"—where stocks drop on good earnings and cryptos flash-crash for no apparent reason—the financial media reaches for the most convenient narrative. Right now, that narrative is "AI CapEx skepticism" or "Geopolitical jitters."
+
+But if you look at the plumbing, a different story emerges. We are witnessing **The Great Unwind**: the mechanical collapse of the Japanese Yen carry trade.
+
+### The Real Problem: The Funding Currency Trap
+
+The real problem isn't that investors have suddenly lost faith in AI. It's that they've lost access to their **Funding Currency**.
+
+For decades, the Bank of Japan's ZIRP (Zero Interest Rate Policy) transformed the Yen into the world's cheap money printer. Wall Street borrowed Yen at 0% to buy everything else—U.S. Treasuries, Tech stocks, and Bitcoin.
+
+**The market isn't reacting to news; it's reacting to margin calls.** When Japan raises rates even slightly, the "free money" trade turns into a debt trap. Trillions of dollars of leveraged positions must be liquidated and converted back to Yen to avoid wipeouts.
+
+### Why This Exists: The Leverage Asymmetry
+
+This exists because of **Leverage Asymmetry**. A generation of traders has never known a world where the Yen wasn't a free lunch.
+
+When the funding currency (Yen) appreciates against the target assets (USD/Tech), it creates a feedback loop of forced selling. The more people sell tech to buy back Yen, the stronger the Yen gets, triggering *more* forced selling.
+
+### The Missing Model: The Correlation Breakdown
+
+The missing model to understand this is the **Correlation Breakdown**.
+
+In a "normal" market correction, uncorrelated assets (like Gold and Tech) move in opposite directions. But in a **Liquidity Crisis**, correlations approach 1.0. This is the "forced liquidation" signature: traders aren't selling what they *want* to sell; they are selling what they *can* sell to raise cash for margin calls.
+
+| Asset | "Normal" Correction | "Carry Unwind" (Jan 2026) |
+| :--- | :--- | :--- |
+| **Big Tech (MSFT)** | Down (Growth fears) | **Down (Liquidity source)** |
+| **Bitcoin** | Variable (Risk off) | **Down (Liquidity source)** |
+| **Gold** | Up (Safe haven) | **Down (Liquidity source)** |
+
+*This is the crux:* When Microsoft, Bitcoin, and Gold all crash on the same day, you aren't seeing a change in "sentiment." You are seeing the plumbing of the global financial system being drained.
+
+### Tradeoffs and Failure Modes
+
+The primary failure mode of this model is **Narrative Displacement**.
+
+1.  **The "AI Bubble" Misdiagnosis:** If we blame AI for a macro liquidity event, we might miss the signal that AI is actually still performing well.
+2.  **The Fed Put Illusion:** Investors waiting for the Fed to "save" the market with rate cuts are ignoring that the BOJ is the one holding the cards this time.
+3.  **The Low VIX Trap:** The VIX (volatility index) often stays low during these events because the selling is orderly and algorithmic, not emotional. It’s a "controlled demolition" of leverage.
+
+### Second-Order Effects: The Repatriation Flow
+
+The second-order effect is a massive **Repatriation of Capital** to Japan.
+
+As Japanese institutional "whales" pull out of U.S. debt and move back into domestic bonds (JGBs), the floor for U.S. Treasuries weakens. We are moving from a world of "Infinite Liquidity" to a world of "Structural Scarcity."
+
+The era of "free money" ended in Tokyo, not New York. If you want to understand why your portfolio is bleeding, stop reading the AI headlines and start watching the USD/JPY swap spreads.
+
+---
+*Inspired by the discussion on HN: [The Great Unwind](https://occupywallst.com/yen)*

--- a/src/content/blog/the-security-capability-gap.md
+++ b/src/content/blog/the-security-capability-gap.md
@@ -1,0 +1,63 @@
+---
+title: "The Security-Capability Gap: Why the Agentic OS is Stalled"
+date: 2026-02-06
+author: "Ganesh Pagade"
+tags: ["ai", "os", "security", "apple"]
+description: "The delay in consumer-grade agentic OS features is driven by a 'Lethal Trifecta' that makes 'Computer Use' too risky for established platforms to ship."
+draft: true
+---
+
+Mac Minis are selling out. They aren't being used as desktop computers; they are being used as headless nodes for "OpenClaw" and other agentic frameworks that allow AI to click buttons and automate workflows.
+
+To many observers, this is proof that Apple and Microsoft have missed the boat. Why is an indie developer launching a "janky" computer-use agent while the world's most valuable companies are still only shipping notification summaries?
+
+### The Real Problem: The Non-Deterministic Root
+
+The real problem isn't a lack of vision; it's the **Non-Deterministic Root**. Operating systems are built on a foundation of predictable, deterministic actions. When you click "Save," the OS saves. When an AI agent clicks "Save," it might save, or it might hallucinate a new prompt, or it might be tricked by a prompt injection attack into deleting the file instead.
+
+**Established platforms cannot ship an agent that has root access to your digital life when the underlying logic engine (the LLM) can be social-engineered.**
+
+### Why This Exists: The Lethal Trifecta
+
+We are currently blocked by the **Lethal Trifecta**. For a consumer-grade platform like iOS or macOS, three forces make agentic "Computer Use" an unacceptable risk:
+
+1.  **Scale:** Apple has ~2.5 billion active devices. A 0.1% failure rate in an agentic workflow isn't an "edge case"; it's 2.5 million disasters.
+2.  **Liability:** If an indie dev's bot accidentally wipes your iCloud, they change the project's name and move on. If Apple's agent does it, they face congressional hearings and multi-billion dollar class-action lawsuits.
+3.  **Prompt Injection:** There is currently no robust, mathematical proof for preventing prompt injection. Any website or email an agent reads is a potential vector for a "remote code execution" attack on your OS through the agent's actions.
+
+### The Missing Model: The Deterministic Sandbox
+
+The path forward isn't "better models"; it's the **Deterministic Sandbox**.
+
+The missing model for the Agentic OS is a layer that separates "Thinking" from "Doing." The LLM (the thinker) proposes an action, but that action must be validated against a set of deterministic, user-defined rules (the sandbox) before it is executed.
+
+```text
+The Deterministic Sandbox:
+
+[ LLM Proposal ] ----> [ Policy Verifier (Hard-Coded) ] ----> [ OS API ]
+                                   ^
+                                   |
+                          [ User-Granted Scope ]
+                          [ Safety Interlocks ]
+```
+
+*Common misconception:* People think we need "Smarter AI" to solve this. We don't. We need "Dumber Guardrails"—hard-coded, non-AI logic that prevents the agent from doing anything irreversible without a biometric confirmation.
+
+### Tradeoffs and Failure Modes
+
+The primary tradeoff is **Utility vs. Safety**.
+
+*   **The "Mother May I" Problem:** If the OS asks for permission for every step, the agent isn't an assistant; it's a nuisance.
+*   **The Implicit Trust Trap:** Users will eventually grow complacent. They will click "Allow" on an agentic action they don't understand, just like they do with cookie banners today.
+*   **The Sandbox Leak:** As soon as you give an agent access to your email to "summarize," you've given it a way to be social-engineered by any sender.
+
+### Second-Order Effects: The Hardware Boom
+
+The second-order effect of this delay is the **"Secondary Hardware" Boom**.
+
+Because big platforms are (rightfully) cautious, power users are buying secondary hardware (like the Mac Mini) to run "unsafe" agents in isolation. We are seeing a return to the "dedicated server" model for personal automation.
+
+Until the OS can provide a cryptographically secure, deterministic boundary for agentic actions, the Agentic OS will remain a niche for those willing to bear the risk themselves. Apple isn't late; they're just not willing to be the first to blow up their users' lives.
+
+---
+*Inspired by the discussion on HN: [OpenClaw is what Apple intelligence should have been](https://www.jakequist.com/thoughts/openclaw-is-what-apple-intelligence-should-have-been)*

--- a/src/content/blog/the-vibe-coding-mirage.md
+++ b/src/content/blog/the-vibe-coding-mirage.md
@@ -1,0 +1,57 @@
+---
+title: "The Vibe-Coding Mirage: Why SaaS Moats are Moving Deeper"
+date: 2026-02-05
+author: "Ganesh Pagade"
+tags: ["ai", "saas", "product-strategy", "architecture"]
+description: "AI agents aren't killing B2B SaaS; they are commoditizing the application layer while making the System of Record and compliance layers the only defensible moats."
+draft: false
+---
+
+The prevailing narrative in Silicon Valley right now is that AI is an existential threat to B2B SaaS. The argument is simple: if a non-technical PM can "vibe-code" a custom internal tool using an agent, why would a company pay $30,000 a year for a seat-based subscription to a "market leader" that only provides 10% of the features they actually use?
+
+It's a compelling story, especially when you see tech stocks lagging and "vibe-coding" demos going viral. But it misses the fundamental reason why SaaS exists in the enterprise.
+
+### The Real Problem: The Outsourcing of Responsibility
+
+The "SaaS is dead" argument assumes that the value of SaaS is in the **Software** (the first S). It isn't. The value of SaaS is in the **Service** (the second S).
+
+Enterprise leaders don't buy software just because they can't build it. They buy it because they don't want to be *responsible* for it. When a developer "slaps together" a Jira-lite over the weekend, they haven't just built a tool; they've built a liability. Who maintains the API integrations when they break? Who ensures SOC 2 compliance? Who handles the audit logs?
+
+**The real problem isn't that software is too expensive; it's that maintaining a custom "vibe-coded" stack is an operational nightmare that no manager wants to own.**
+
+### Why This Exists: The Abstraction Trap
+
+We are currently caught in the **Abstraction Trap**. AI has lowered the cost of *authoring* code to near zero, but it has not lowered the cost of *architecting* or *maintaining* systems.
+
+In the old world, the friction of writing code forced a "Buy vs. Build" decision. Most chose "Buy" because "Build" was too hard. In the AI world, "Build" looks easy, so people are jumping in without realizing that the software layer is just the tip of the iceberg.
+
+### The Missing Model: The Moat Shift
+
+To understand the future of SaaS, we need to look at where the moats are moving. We are seeing a **Moat Shift** from the Application Layer to the System of Record (SoR) and Governance layers.
+
+| Layer | Old Moat (Pre-AI) | New Reality (Post-AI) |
+| :--- | :--- | :--- |
+| **Application (UI/Logic)** | Proprietary features, "Sticky" UX | **Commoditized.** Agents can replicate any UI or logic flow. |
+| **System of Record (Data)** | Hard to export, integrated workflows | **Defensible.** The single source of truth is the ultimate lock-in. |
+| **Governance / Compliance** | Manual audits, security reviews | **Critical.** Automated SOC 2, HIPAA, and audit trails are the new baseline. |
+
+*This is the crux:* AI commoditizes the "Software" but drastically increases the complexity of the "Service." The survivors won't be the SaaS companies with the best features; they'll be the ones who become the most reliable **Platforms of Record.**
+
+### Tradeoffs and Failure Modes
+
+The primary failure mode of this model is **Management Hubris**.
+
+1.  **The Shadow IT Explosion:** If every department vibe-codes their own CRM, the company loses its unified view of the customer. Data silos return with a vengeance.
+2.  **The "Vibe-Coded" Security Hole:** Non-technical teams building tools don't think about XSS, CSRF, or rate limiting. They build "functional" tools that are fundamentally insecure.
+3.  **The Maintenance Debt:** An agent can write the first 1,000 lines of a tool, but it won't be there to fix a production bug at 2 AM on a Saturday.
+
+### Second-Order Effects: The "Second S" Dominance
+
+The second-order effect is that SaaS will pivot from "Tools" to "Verification."
+
+We will see a rise in **Meta-SaaS**: products that don't provide the tool itself, but provide the *governance and deployment framework* for your vibe-coded tools. Instead of buying a CRM, you'll buy a "Secure Data Plane" and let your agents build the UI on top of it.
+
+The SaaS industry isn't dying; it's just shedding its skin. The software layer is gone, but the responsibility layer is more valuable than ever.
+
+---
+*Inspired by the discussion on HN: [AI is killing B2B SaaS](https://nmn.gl/blog/ai-killing-b2b-saas)*


### PR DESCRIPTION
As "Scribe", I scanned the top 30 Hacker News posts and analyzed the discourse to identify missing models and senior-level insights.

I synthesized three standalone essays following a mandatory 5-part logical arc:
1. **The Vibe-Coding Mirage**: Analyzes the shift in B2B SaaS moats from the application layer to the "System of Record" and responsibility layer.
2. **The Security-Capability Gap**: Explores why major OS platforms are cautious about agentic "Computer Use" due to the "Lethal Trifecta" of scale, liability, and prompt injection.
3. **The Plumbing of Volatility**: Connects recent market crashes to the mechanical deleveraging of the Japanese Yen carry trade unwind.

Each post includes visual structures (tables/sketches) to improve clarity.
The editorial journal (.Jules/scribe.md) was updated with learnings about the "Software vs. Service" split in industry discourse.

---
*PR created automatically by Jules for task [7140712090857453941](https://jules.google.com/task/7140712090857453941) started by @rockoder*