### PR TITLE
Scribe Editorial Publication - 2026-02-19

### DIFF
--- a/.scribe/beyondthecode-journal.md
+++ b/.scribe/beyondthecode-journal.md
@@ -53,3 +53,19 @@
 **Learning:** Initial hero image used made-up TypeScript about "feature velocity" and "comprehension metrics." Felt fake. Replaced with real Python — an async connection pool with semaphores and locks. The critical section (race condition handling) blurs out. Real code that engineers recognize is more effective than code that illustrates the essay's concepts literally.
 
 **Implication:** Visual elements should ground the essay in recognizable reality, not mirror its abstractions. Show production code, not conceptual code.
+
+---
+
+## 2026-02-19 – The Reach Tax and the Devaluation of Quality
+
+**Learning:** When the marginal cost of production drops to zero, the market does not democratize; it financializes. The "moat" moves from the ability to *make* something to the ability to *buy* an audience for it. Reach exhibits threshold effects—below a certain level of existing capital or attention, quality is irrelevant because it is statistically invisible.
+
+**Implication:** Future writing should distinguish between "creation-limited" eras (where skill was the filter) and "distribution-limited" eras (where capital or existing reach is the filter). Analyzing a product's "quality" in a distribution-limited market is a category error.
+
+---
+
+## 2026-02-19 – Institutional Gravity vs. Technical Interop
+
+**Learning:** Programming languages are not merely compilers; they are institutional artifacts. The friction in adoption often stems not from syntax but from a collision between different "ecosystem gravities." Interop fails at the semantic boundaries of how different communities think about memory, build artifacts, and ownership.
+
+**Implication:** When evaluating language adoption, the primary risk is often the "pioneer tax"—the cost of building the missing institutional infrastructure that the language's primary patron never required.

--- a/src/content/beyondthecode/institutional-gravity.md
+++ b/src/content/beyondthecode/institutional-gravity.md
@@ -1,0 +1,17 @@
+---
+title: "Institutional Gravity"
+date: 2026-02-19
+description: "Technical interoperability often fails not because of syntax, but because languages carry the institutional baggage of their primary ecosystems."
+author: "Ganesh Pagade"
+draft: false
+---
+
+The attempt to adopt a programming language into an established project is often framed as a technical evaluation of features, safety, and performance. In practice, this process frequently reveals a more stubborn obstacle: institutional gravity.
+
+Every language is born into an ecosystem that shapes its metaphors for memory, ownership, and build artifacts. When a project rooted in one tradition—such as C++ development for Linux—attempts to integrate a language from a different tradition, the friction usually occurs at the semantic boundaries.
+
+Consider the recent challenges of integrating Swift into a non-Apple-centric environment. The language itself is expressive and safe, but it carries the gravity of its primary patron. Its build systems, interop patterns, and even its core library assumptions are optimized for a specific set of platforms and institutional needs. To use it elsewhere is to pay a "pioneer tax"—the ongoing cost of building and maintaining the infrastructure that the language's primary ecosystem takes for granted.
+
+This friction is often mistaken for a lack of maturity or technical flaws in the interop layer. More accurately, it is a collision of two different models of software construction. One ecosystem might prioritize tight integration and vertical control, while the other values modularity and platform independence. When these gravities collide, the cost of bridging the gap often outweighs the theoretical benefits of the new language.
+
+Technical interoperability, then, is as much a social and institutional problem as it is a compiler problem. A language is not merely a set of rules for transforming text into instructions; it is a repository of the assumptions of the community that built it. Organizations that ignore this gravity find themselves fighting the toolchain as often as they fight the problem they set out to solve.

--- a/src/content/beyondthecode/the-reach-tax.md
+++ b/src/content/beyondthecode/the-reach-tax.md
@@ -1,0 +1,17 @@
+---
+title: "The Reach Tax"
+date: 2026-02-19
+description: "When the marginal cost of production drops to zero, the bottleneck shifts from the ability to create to the ability to be noticed."
+author: "Ganesh Pagade"
+draft: false
+---
+
+In a creation-limited era, the filter is skill. When producing a functional software product or a coherent essay requires months of concentrated effort, the mere existence of the output serves as a signal of intent and capability. The "moat" in such an environment is the difficulty of the work itself.
+
+As generative tools reduce the marginal cost of production toward zero, this filter dissolves. The market transitions from a state of creation-limited scarcity to distribution-limited abundance. In this new dynamic, the quality of an individual artifact becomes secondary to the existing reach of its creator.
+
+This shift introduces what might be called the Reach Tax. In a distribution-limited market, a new entrant often faces threshold effects that are non-linear. Below a certain level of existing attention or capital, even high-quality work can remain statistically invisible, drowned out by the sheer volume of low-cost alternatives. Above that threshold, reach becomes gravitational—it accumulates without the need for constant reinvestment, as existing nodes in the network find and amplify the work.
+
+The consequence for early-stage founders and independent creators is a fundamental change in risk profile. Where once the primary risk was technical (can we build it?), the primary risk is now structural (can we afford to be seen?). Organizations with established distribution channels find their advantage compounded, as they can ship incremental or even mediocre improvements into a captive audience, while superior but unfunded alternatives fail to reach the threshold of awareness.
+
+This dynamic tends to reward capital over craftsmanship. When creation is commoditized, the "moat" moves to where the friction remains. In 2026, the friction is not in the pixels or the prose, but in the finite attention of a human audience.


### PR DESCRIPTION
Published two new editorial essays based on today's Hacker News scan. Updated the editorial journal with key insights on distribution-limited markets and ecosystem gravity in language adoption. Verified visual rendering and site build integrity.

---
*PR created automatically by Jules for task [10039251907830068352](https://jules.google.com/task/10039251907830068352) started by @rockoder*