### PR TITLE
Scribe Essays: Skill Atrophy and the IC-as-Manager

### DIFF
--- a/.scribe/beyondthecode-journal.md
+++ b/.scribe/beyondthecode-journal.md
@@ -53,3 +53,19 @@
 **Learning:** Initial hero image used made-up TypeScript about "feature velocity" and "comprehension metrics." Felt fake. Replaced with real Python — an async connection pool with semaphores and locks. The critical section (race condition handling) blurs out. Real code that engineers recognize is more effective than code that illustrates the essay's concepts literally.
 
 **Implication:** Visual elements should ground the essay in recognizable reality, not mirror its abstractions. Show production code, not conceptual code.
+
+---
+
+## 2026-02-22 – The Reviewer’s Paradox and Skill Atrophy
+
+**Learning:** Engineering judgment is not a static library; it is a muscle that atrophies without direct engagement with problem-solving. Decoupling the senior engineer from the act of "doing" to maximize "reviewing" creates a fragile organizational layer. The reviewer eventually loses the edge required to audit the machine they are supposed to supervise.
+
+**Implication:** Organizations should be wary of measuring seniority purely by review throughput or agent shepherding. The act of struggle is a necessary investment in future judgment.
+
+---
+
+## 2026-02-22 – The Administrative Tax of AI Leverage
+
+**Learning:** AI leverage does not eliminate work; it transforms it. The time saved on implementation is being reallocated into a new middle-management layer for Individual Contributors. Workflows like "Research -> Plan -> Annotate -> Implement" are essentially managerial overhead applied to the terminal.
+
+**Implication:** Headcount planning that assumes AI reduces the need for engineers ignores the increased complexity and administrative burden of managing agentic output. Velocity is high, but the "judgment tax" is increasing.

--- a/src/content/beyondthecode/the-ic-as-manager-navigating-the-administrative-tax-of-ai-leverage.md
+++ b/src/content/beyondthecode/the-ic-as-manager-navigating-the-administrative-tax-of-ai-leverage.md
@@ -1,0 +1,23 @@
+---
+title: "The IC-as-Manager: Navigating the Administrative Tax of AI Leverage"
+date: 2026-02-22
+description: "As coding agents take over implementation, the individual contributor role is being reshaped into a middle-management layer for AI."
+author: "Ganesh Pagade"
+draft: false
+---
+
+A new engineering workflow has begun to circulate in high-performing teams, characterized by a strict separation of planning and execution. The individual contributor (IC) no longer starts with a code editor; they start with a research document. They instruct the agent to "read deeply," to "understand intricacies," and to "find all the bugs" before a single line of feature code is proposed.
+
+This is the emergence of the IC-as-Manager. In this model, the engineer’s primary output is no longer the pull request, but the annotated plan. They spend their hours in an iterative cycle of reviewing the agent’s research, correcting its architectural assumptions, and adding "don't implement yet" guards to prevent the machine from drifting into hallucinated APIs or over-engineered solutions.
+
+The promise of AI leverage was the elimination of "boring" boilerplate and the acceleration of feature delivery. But in many organizations, this leverage has introduced a new, silent administrative tax. The time saved on typing is being redirected into a multi-stage managerial ritual. The engineer must now manage the "energetic intern" that lives in their terminal.
+
+This shift recalibrates the definition of Engineering Maturity. In the traditional IC model, maturity was evidenced by the ability to navigate complex codebases and ship reliable features autonomously. In the AI-leveraged model, maturity is evidenced by the ability to maintain a "shared mutable state" with an agent—using markdown files as a debugging surface for the model’s assumptions.
+
+The incentive mismatch occurs at the layer of organizational legibility. To a VP of Engineering, the velocity looks incredible. Features that used to take weeks are now appearing in days. But to the Staff Engineer, the nature of the work has changed from creative problem-solving to high-stakes proofreading. They are now responsible for the judgment calls that the agent cannot make—product priorities, technical debt trade-offs, and the organizational "taste" that defines a company’s engineering culture.
+
+This management overhead is not merely a tooling shift; it is a structural change in the IC role. The "Software Manager" of the AI age is an IC who has captured the leverage of the machine but has also absorbed the administrative burden of its unreliability. They are the supervisor of a tireless, boundless energy that requires constant, precise steering.
+
+The second-order consequence is a tension in headcount planning. If every IC is now a manager of agentic throughput, the organization might assume it needs fewer engineers. But the administrative tax of managing agents—the research phases, the annotation cycles, the verification rituals—suggests that while the *output* per engineer is higher, the *complexity* of the engineer’s role has increased.
+
+The successful engineer in this environment is the one who accepts that their job is no longer to write code, but to manage the intent that produces it. They are the architect of the prompt and the auditor of the artifact. They have become the middle-management layer of the machine, a role that requires more judgment than ever, but offers fewer moments of the quiet, focused craft that drew them to engineering in the first place.

--- a/src/content/beyondthecode/the-reviewers-paradox-skill-atrophy-in-the-age-of-agentic-velocity.md
+++ b/src/content/beyondthecode/the-reviewers-paradox-skill-atrophy-in-the-age-of-agentic-velocity.md
@@ -1,0 +1,25 @@
+---
+title: "The Reviewer’s Paradox: Skill Atrophy in the Age of Agentic Velocity"
+date: 2026-02-22
+description: "When senior engineers shift from solving problems to rubber-stamping agentic output, the organizational definition of seniority begins to hollow out."
+author: "Ganesh Pagade"
+draft: false
+---
+
+A Senior Engineer at a high-growth fintech firm recently noted that their team had reached a milestone: one thousand pull requests generated per week. The metric was presented in a Quarterly Business Review as a triumph of leverage. The "Minions"—internal coding agents—were doing the heavy lifting, allowing the humans to focus on "higher-level architecture."
+
+In practice, the calendar tells a different story. The Staff Engineer who once spent mornings in deep work, navigating the edge cases of distributed consensus or optimizing database transaction isolation, now spends those same hours in a relentless queue of review. They are the human-in-the-loop, the final safety check before an agentic flood of code hits production.
+
+The transition from contributor to reviewer is often framed as a promotion. It is described as a shift from "Output Capital" to "Judgment Capital." If an agent can write the code in seconds, the human’s value must surely lie in knowing whether that code is correct. But this framing ignores a fundamental biological reality of engineering: judgment is a byproduct of struggle.
+
+When an engineer writes code, they are not just typing; they are building a mental model through a series of failed hypotheses. They encounter the race condition, they struggle with the poorly documented API, they feel the friction of the existing abstraction. This struggle is what sharpens the intuition required to review code effectively.
+
+The Reviewer’s Paradox emerges when the organization optimizes for throughput. As agents take over the "boring" implementation, the senior engineer is decoupled from the act of problem-solving. They begin to review code they did not have to think through. Initially, their years of experience carry them. They spot the obvious errors, the anti-patterns they’ve seen a hundred times.
+
+But experience is a decaying asset. Without the constant recalibration that comes from direct engagement with the material, the reviewer’s edge dulls. They become increasingly reliant on the agent’s own tests and summaries. The review process shifts from a critical audit to a form of administrative rubber-stamping.
+
+This shift is most visible during promotion calibration meetings. In the pre-agent era, seniority was often measured by the complexity of the problems an engineer could solve. Now, the metric is shifting toward "review bandwidth"—how much agentic output an engineer can safely shepherd into the codebase.
+
+The Director sees a team shipping ten times faster and labels it a success. But the Staff Engineer feels the quiet erosion of their technical depth. They are becoming a manager of a system they no longer fully inhabit.
+
+The danger is not that the AI will make a mistake; the danger is that when it does, the human reviewer will no longer have the localized context or the sharpened intuition to notice. In the pursuit of velocity, the organization is trading long-term technical competence for short-term throughput, effectively turning its most expensive talent into a sophisticated, but increasingly fragile, quality assurance layer.


### PR DESCRIPTION
### Selected HN Posts
- https://news.ycombinator.com/item?id=47106686 (How I use Claude Code: Separation of planning and execution)
- https://news.ycombinator.com/item?id=47110495 (Minions: Stripe's one-shot, end-to-end coding agents)
- https://news.ycombinator.com/item?id=47103418 (The Software Development Lifecycle Is Dead)

### Selection Reasoning
- **The IC-as-Manager**: The discussion around "Claude Code" workflows revealed a shift where engineers are adopting multi-stage planning and annotation rituals. This reflects a durable structural shift where "Judgment Capital" requires a new form of administrative overhead.
- **The Reviewer's Paradox**: The Stripe "Minions" post and the "SDLC is Dead" narrative surface a conflict between throughput (1000 PRs/week) and the erosion of human technical depth. It identifies a gap in how seniority is measured versus how technical skill is maintained.

### Conceptual Gap Identified
- **The Administrative Tax of AI**: Organizations optimize for velocity but fail to account for the increased complexity of the "intent management" role that replaces traditional coding.
- **The Feedback Loop of Judgment**: Acknowledging that the ability to review code is a byproduct of the struggle of writing it, and that decoupling these acts leads to organizational fragility.

### Essay Mapping
- `the-reviewers-paradox-skill-atrophy-in-the-age-of-agentic-velocity.md` -> Derived from debates in the Stripe Minions and SDLC Dead threads regarding review fatigue and skill decay.
- `the-ic-as-manager-navigating-the-administrative-tax-of-ai-leverage.md` -> Derived from the "Software Manager" framing of AI-assisted workflows in the Claude Code thread.

### Quotes
- "LLM's are like unreliable interns with boundless energy. They make silly mistakes, wander into annoying structural traps, and have to be unwound if left to their own devices."
- "If these are mostly migrations, boilerplate, and bug fixes on previous Minion PRs that were bug ridden, then you've just created 1000 code reviews/week to waste human time rubber-stamping."
- "One thing I don’t see developers talking about much is that if your job is to only read code instead of writing it, how do you expect to stay good at reviewing code if you never write it?"
- "The entire lifecycle, the one we’ve built careers around, the one that spawned a multi-billion dollar tooling industry, is collapsing in on itself."

---
*PR created automatically by Jules for task [4072200730538907455](https://jules.google.com/task/4072200730538907455) started by @rockoder*